### PR TITLE
Possible to use trait for Admin class

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -36,7 +36,7 @@
         "matthiasnoback/symfony-dependency-injection-test": "^4.1",
         "phpunit/phpunit": "^9.5",
         "psr/container": "^1.1 || ^2.0",
-        "runroom-packages/testing": "^0.16",
+        "runroom-packages/testing": "^0.15",
         "sonata-project/admin-bundle": "^3.103 || ^4.9",
         "sonata-project/doctrine-orm-admin-bundle": "^3.34 || ^4.0",
         "symfony/framework-bundle": "^4.4 || ^5.4 || ^6.0",

--- a/src/Admin/AbstractSortableAdmin.php
+++ b/src/Admin/AbstractSortableAdmin.php
@@ -14,8 +14,6 @@ declare(strict_types=1);
 namespace Runroom\SortableBehaviorBundle\Admin;
 
 use Sonata\AdminBundle\Admin\AbstractAdmin;
-use Sonata\AdminBundle\Route\RouteCollection;
-use Sonata\AdminBundle\Route\RouteCollectionInterface;
 
 /**
  * @template T of object
@@ -24,21 +22,5 @@ use Sonata\AdminBundle\Route\RouteCollectionInterface;
  */
 abstract class AbstractSortableAdmin extends AbstractAdmin
 {
-    /**
-     * @param mixed[] $sortValues
-     */
-    protected function configureDefaultSortValues(array &$sortValues): void
-    {
-        $sortValues['_sort_by'] = 'position';
-    }
-
-    /**
-     * @todo: Simplify this when dropping support for Sonata 3
-     *
-     * @param RouteCollection|RouteCollectionInterface $collection
-     */
-    protected function configureRoutes(object $collection): void
-    {
-        $collection->add('move', $this->getRouterIdParameter() . '/move/{position}');
-    }
+    use SortableAdminTrait;
 }

--- a/src/Admin/SortableAdminTrait.php
+++ b/src/Admin/SortableAdminTrait.php
@@ -26,5 +26,5 @@ trait SortableAdminTrait
         $collection->add('move', $this->getRouterIdParameter() . '/move/{position}');
     }
 
-    abstract function getRouterIdParameter(): string;
+    abstract public function getRouterIdParameter(): string;
 }

--- a/src/Admin/SortableAdminTrait.php
+++ b/src/Admin/SortableAdminTrait.php
@@ -1,0 +1,30 @@
+<?php
+declare(strict_types=1);
+
+namespace Runroom\SortableBehaviorBundle\Admin;
+
+use Sonata\AdminBundle\Route\RouteCollection;
+use Sonata\AdminBundle\Route\RouteCollectionInterface;
+
+trait SortableAdminTrait
+{
+    /**
+     * @param mixed[] $sortValues
+     */
+    protected function configureDefaultSortValues(array &$sortValues): void
+    {
+        $sortValues['_sort_by'] = 'position';
+    }
+
+    /**
+     * @todo: Simplify this when dropping support for Sonata 3
+     *
+     * @param RouteCollection|RouteCollectionInterface $collection
+     */
+    protected function configureRoutes(object $collection): void
+    {
+        $collection->add('move', $this->getRouterIdParameter() . '/move/{position}');
+    }
+
+    abstract function getRouterIdParameter(): string;
+}


### PR DESCRIPTION
My case I use own abstract admin, that can use or not RunroomSortableBehavior/AbstractSortableAdmin. So easiest way is to declare trait, that I can attach to some Admin classes.