### PR TITLE
Fix drag and drop get position

### DIFF
--- a/src/Service/AbstractPositionHandler.php
+++ b/src/Service/AbstractPositionHandler.php
@@ -68,6 +68,9 @@ abstract class AbstractPositionHandler implements PositionHandlerInterface
                 $newPosition = $lastPosition;
                 break;
         }
+        if (is_numeric($movePosition)) {
+            $newPosition = (int)$movePosition;
+        }
 
         return max(0, min($newPosition, $lastPosition));
     }


### PR DESCRIPTION
For drag and drop functionallity, from controller could come new position as numeric. In such case getPosition return same position of object and as result nothing is changed.
https://github.com/Runroom/RunroomSortableBehaviorBundle/blob/master/src/Action/MoveAction.php#L64